### PR TITLE
Update p1_to_influxdb.py

### DIFF
--- a/p1_to_influxdb.py
+++ b/p1_to_influxdb.py
@@ -52,18 +52,19 @@ while True:
                         if getattr(obis_references,obis_name)==key:
                             name=obis_name
                             break
-
-
+                    
+                    #Filter out failure log entries
+                    if name!="POWER_EVENT_FAILURE_LOG": 
                     #is it a number?
-                    if isinstance(value.value, int) or isinstance(value.value, decimal.Decimal):
-                        nr=float(value.value)
-                        #filter duplicates gas , since its hourly. (we want to be able to differentiate it, duplicate values confuse that)
-                        if name=='HOURLY_GAS_METER_READING':
-                            if prev_gas!=None and nr!=prev_gas:
+                        if isinstance(value.value, int) or isinstance(value.value, decimal.Decimal):
+                            nr=float(value.value)
+                            #filter duplicates gas , since its hourly. (we want to be able to differentiate it, duplicate values confuse that)
+                            if name=='HOURLY_GAS_METER_READING':
+                                if prev_gas!=None and nr!=prev_gas:
+                                    influx_measurement['fields'][name]=float(value.value)
+                                prev_gas=nr
+                            else:
                                 influx_measurement['fields'][name]=float(value.value)
-                            prev_gas=nr
-                        else:
-                            influx_measurement['fields'][name]=float(value.value)
 
 
             pprint.pprint(influx_measurement)


### PR DESCRIPTION
If a Power Failure log is available, the code fails on line 59 with an " 'ProfileGenericObject' object has no attribute 'value'" error as the log doesn't have a value attribute. Since we do not want to add this log to Influx, I've added a line do disregard these entries.